### PR TITLE
Update Swagger UI URL from port 8080 to 8081 in README

### DIFF
--- a/search-service/README.md
+++ b/search-service/README.md
@@ -36,7 +36,7 @@ docker-compose -f ./docker/docker-compose.yml up
  mvn spring-boot:run
  ```
 
-Open the Swagger UI for REST services at `http://localhost:8080`.
+Open the Swagger UI for REST services at `http://localhost:8081`.
 
 ## Docker hub
 


### PR DESCRIPTION
Following the `search-service/README.md`:

<img width="872" height="719" alt="image" src="https://github.com/user-attachments/assets/2667eb49-e1f6-43b5-9fa2-f70fc629c0d7" />
