### PR TITLE
Update README with manual setup instructions

### DIFF
--- a/common-ui/README.md
+++ b/common-ui/README.md
@@ -12,6 +12,7 @@ Set the yarn link. Use the `./link_common_ui.sh` script to link the `common-ui` 
 Or if you prefer to do it manually, follow these steps:
 1. In the `common-ui` directory, run:
 ```bash
+yarn install
 yarn link
 ```
 2. In your `-ui` project directory, run:


### PR DESCRIPTION
Added instructions for manual setup using yarn.

If not, other commands fails, like:
```
yarn test
yarn run v1.22.22
warning package.json: No license field
$ jest
/bin/sh: 1: jest: not found
error Command failed with exit code 127.
```