### PR TITLE
Fix for useHashState tests

### DIFF
--- a/common-ui/src/util/useHashState.test.tsx
+++ b/common-ui/src/util/useHashState.test.tsx
@@ -9,24 +9,14 @@ import {act} from 'react';
 import useHashState from './useHashState';
 
 describe('useHashState', () => {
-    const originalLocation = window.location;
-
     beforeEach(() => {
-        // Mock window.location and window.addEventListener/removeEventListener
-        Object.defineProperty(window, 'location', {
-            writable: true,
-            value: {...originalLocation, hash: '',},
-        });
+        window.location.hash = '';
         jest.spyOn(window, 'addEventListener');
         jest.spyOn(window, 'removeEventListener');
     });
 
     afterEach(() => {
-        // Restore original window.location
-        Object.defineProperty(window, 'location', {
-            writable: true,
-            value: originalLocation,
-        });
+        window.location.hash = '';
         jest.restoreAllMocks();
     });
 
@@ -56,7 +46,6 @@ describe('useHashState', () => {
         expect(result.current[0]).toEqual({key: 'value'});
     });
 
-
     it('should stringify and encode JSON values when setHashValue is called with an object', () => {
         const {result} = renderHook(() => useHashState('test', {}));
         act(() => {
@@ -77,7 +66,7 @@ describe('useHashState', () => {
         act(() => {
             result.current[1](undefined);
         });
-        expect(window.location.hash).toBe('#');
+        expect(window.location.hash).toBe('');
     });
 
     it('should remove the hash key when setHashValue is called with null', () => {
@@ -86,7 +75,7 @@ describe('useHashState', () => {
         act(() => {
             result.current[1](null);
         });
-        expect(window.location.hash).toBe('#');
+        expect(window.location.hash).toBe('');
     });
 
     it('should not update the hash if the new value is the same as the current value', () => {
@@ -140,7 +129,7 @@ describe('useHashState', () => {
         act(() => {
             result.current[1]('default');
         });
-        expect(window.location.hash).toBe('#');
+        expect(window.location.hash).toBe('');
     });
 
     it('should be able to modify one hash parameter without changing others', () => {
@@ -149,7 +138,6 @@ describe('useHashState', () => {
         act(() => {
             result.current[1]('changedValue');
         });
-
         const hashParams = new URLSearchParams(window.location.hash.substring(1));
         expect(hashParams.get('test')).toBe('changedValue');
         expect(hashParams.get('another')).toBe('anotherValue');


### PR DESCRIPTION
Currently, the test fails with:

```
yarn run v1.22.22
warning package.json: No license field
$ jest
FAIL src/util/useHashState.test.tsx
  useHashState
    ✕ should return the default value when hash is empty (6 ms)
    ✕ should return the value from the hash when it exists (1 ms)
    ✕ should update the hash and state when setHashValue is called (1 ms)
    ✕ should parse encoded JSON values from the hash (1 ms)
    ✕ should stringify and encode JSON values when setHashValue is called with an object (1 ms)
    ✕ should handle invalid JSON in the hash and return the value as a string (1 ms)
    ✕ should remove the hash key when setHashValue is called with undefined
    ✕ should remove the hash key when setHashValue is called with null (1 ms)
    ✕ should not update the hash if the new value is the same as the current value (1 ms)
    ✕ should use the function to update the state if setHashValue is passed a function
    ✕ should add event listener when enableListener is true
    ✕ should remove event listener when enableListener is true and unmounted (1 ms)
    ✕ should update the state when hash changes and enableListener is true (1 ms)
    ✕ should not add event listener when enableListener is false
    ✕ should delete the key if new value is default value (1 ms)
    ✕ should be able to modify one hash parameter without changing others (1 ms)

(...)
  ● useHashState › should be able to modify one hash parameter without changing others

    TypeError: Cannot redefine property: location
        at Function.defineProperty (<anonymous>)

      24 |     afterEach(() => {
      25 |         // Restore original window.location
    > 26 |         Object.defineProperty(window, 'location', {
         |                ^
      27 |             writable: true,
      28 |             value: originalLocation,
      29 |         });

      at Object.defineProperty (src/util/useHashState.test.tsx:26:16)

PASS src/components/fontAwesomeIconLite.test.tsx
  FontAwesomeIconLite
    ✓ renders the SVG element (37 ms)
    ✓ sets the correct class name (6 ms)
    ✓ sets the correct viewBox attribute (6 ms)
    ✓ renders the path element with correct fill color and d attribute (5 ms)

PASS src/components/dualRangeSlider.test.tsx
  DualRangeSlider
    ✓ displays the 2 buttons, range bar and selection (141 ms)
    ✓ check min slider mouse drag (61 ms)
    ✓ check min slider mouse drag when singleValue mode (26 ms)
    ✓ check max slider mouse drag (20 ms)
    ✓ check max slider key events (23 ms)
    ✓ check min slider key events (17 ms)
    ✓ disables sliders when isDisabled is true (13 ms)
    ✓ renders single value slider when singleValue is true (9 ms)

Test Suites: 1 failed, 2 passed, 3 total
Tests:       16 failed, 12 passed, 28 total
Snapshots:   0 total
Time:        3.382 s
Ran all test suites.
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.


```