### PR TITLE
Feat/runtime theme min (search-ui)

### DIFF
--- a/common-ui/src/components/footer.tsx
+++ b/common-ui/src/components/footer.tsx
@@ -12,7 +12,8 @@ interface FooterProps {
     loginFn?: () => void,
     logoutFn?: () => void,
     footerUrl: string, // URL to fetch the external footer HTML
-    containerClass?: string // container-fluid (default) or container
+    containerClass?: string, // container-fluid (default) or container
+    logoUrl?: string // optional theme logo, substituted for {{logoUrl}} in the footer mustache
 }
 
 /**
@@ -39,7 +40,7 @@ interface FooterProps {
  * @constructor
  */
 
-function Footer({isLoggedIn, loginFn, logoutFn, footerUrl, containerClass}: FooterProps) {
+function Footer({isLoggedIn, loginFn, logoutFn, footerUrl, containerClass, logoUrl}: FooterProps) {
 
     const [externalFooterHtml, setExternalFooterHtml] = useState('');
 
@@ -48,9 +49,11 @@ function Footer({isLoggedIn, loginFn, logoutFn, footerUrl, containerClass}: Foot
     // fetch the external footer html
     useEffect(() => {
         if (footerUrl) {
+            // Default to the ALA logo so footers that don't supply a theme logoUrl keep working.
+            const resolvedLogoUrl = logoUrl || 'https://www.ala.org.au/app/uploads/2019/01/logo.png';
             fetch(footerUrl)
                 .then((response) => response.text())
-                .then((text) => setExternalFooterHtml(cleanMustache(text, containerClass || 'container-fluid')));
+                .then((text) => setExternalFooterHtml(cleanMustache(text, containerClass || 'container-fluid', undefined, resolvedLogoUrl)));
         }
     }, []);
 

--- a/common-ui/src/components/header.tsx
+++ b/common-ui/src/components/header.tsx
@@ -19,7 +19,8 @@ interface HeaderProps {
     headerUrl: string, // URL to fetch the external header HTML
     searchBaseUrl?: string, // Optional searchURL for mustache templates
     containerClass?: string, // container-fluid (default) or container
-    jsUrl?: string // comma-delimited JS URLs to load after header HTML is ready
+    jsUrl?: string, // comma-delimited JS URLs to load after header HTML is ready
+    logoUrl?: string // optional theme logo, substituted for {{logoUrl}} in the header mustache
 }
 
 /**
@@ -48,7 +49,7 @@ interface HeaderProps {
  * @param jsUrl java script URLs to load, supports a comma delimited list
  * @constructor
  */
-function Header({isLoggedIn, loginFn, logoutFn, headerUrl, searchBaseUrl, containerClass, jsUrl}: HeaderProps) {
+function Header({isLoggedIn, loginFn, logoutFn, headerUrl, searchBaseUrl, containerClass, jsUrl, logoUrl}: HeaderProps) {
 
     const [externalHeaderHtml, setExternalHeaderHtml] = useState('');
 
@@ -57,10 +58,13 @@ function Header({isLoggedIn, loginFn, logoutFn, headerUrl, searchBaseUrl, contai
     // fetch the external header html
     useEffect(() => {
         if (headerUrl) {
+            // Default to the ALA logo so UIs that don't supply a theme logoUrl keep working
+            // (the shared banner.mustache uses {{logoUrl}}).
+            const resolvedLogoUrl = logoUrl || 'https://www.ala.org.au/app/uploads/2019/01/logo.png';
             fetch(headerUrl)
                 .then((response) => response.text())
                 .then((text) => {
-                    setExternalHeaderHtml(cleanMustache(text, containerClass || 'container-fluid', searchBaseUrl));
+                    setExternalHeaderHtml(cleanMustache(text, containerClass || 'container-fluid', searchBaseUrl, resolvedLogoUrl));
                 });
         }
     }, []);

--- a/common-ui/src/hooks/useTheme.ts
+++ b/common-ui/src/hooks/useTheme.ts
@@ -1,0 +1,48 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import {useEffect, useState} from 'react';
+import {ThemeConfig, fetchThemeConfig} from '../util/theme';
+import {injectCommonInfo} from '../util/utils';
+
+interface UseThemeOptions {
+    themeConfigUrl: string; // value of VITE_THEME_CONFIG_URL ('' => use fallbackTheme)
+    fallbackTheme: ThemeConfig; // built-in defaults, typically derived from VITE_* env vars
+    buildInfo: any;
+    env: string;
+}
+
+export interface UseThemeResult {
+    cssLoaded: boolean; // mirrors the existing injectCommonInfo gate
+    themeConfig: ThemeConfig | null; // resolved theme (manifest or fallback)
+}
+
+/**
+ * Minimal runtime-theme hook. Replaces the per-UI `injectCommonInfo` useEffect: it resolves a
+ * theme manifest (or the env-var fallback) and injects its CSS, then exposes the resolved
+ * config so the caller can wire header/footer/logo URLs into <Header>/<Footer>.
+ *
+ * Locale switching is intentionally NOT handled here yet (see SPEC.md "Deferred"); the
+ * existing IntlProvider in each UI's main.tsx is left untouched.
+ */
+export function useTheme({themeConfigUrl, fallbackTheme, buildInfo, env}: UseThemeOptions): UseThemeResult {
+    const [cssLoaded, setCssLoaded] = useState(false);
+    const [themeConfig, setThemeConfig] = useState<ThemeConfig | null>(null);
+
+    useEffect(() => {
+        let cancelled = false;
+        fetchThemeConfig(themeConfigUrl, fallbackTheme).then((cfg) => {
+            if (cancelled) return;
+            setThemeConfig(cfg);
+            injectCommonInfo(buildInfo, env, cfg.cssUrls.join(','), setCssLoaded);
+        });
+        return () => {
+            cancelled = true;
+        };
+    }, []);
+
+    return {cssLoaded, themeConfig};
+}

--- a/common-ui/src/index.ts
+++ b/common-ui/src/index.ts
@@ -31,6 +31,9 @@ import useHashState from "./util/useHashState.tsx";
 import {injectCommonInfo, injectCommonJs} from "./util/utils.tsx";
 import {UserContext, useUser, UserInfo} from "./util/UserContext.tsx";
 import {checkLoginState, handleLogin, handleLogout} from "./util/auth.tsx";
+import {useTheme, UseThemeResult} from "./hooks/useTheme.ts";
+import {fetchThemeConfig, fetchLocaleMessages, ThemeConfig, ThemeLocale} from "./util/theme.ts";
+import {getRuntimeConfig} from "./util/runtimeConfig.ts";
 
 export {
     Banner,
@@ -66,8 +69,12 @@ export {
     useUser,
     handleLogin,
     handleLogout,
-    checkLoginState
+    checkLoginState,
+    useTheme,
+    fetchThemeConfig,
+    fetchLocaleMessages,
+    getRuntimeConfig
 };
 
-export type {Breadcrumb, RefineSectionItem, ConservationStatusKey, UserInfo};
+export type {Breadcrumb, RefineSectionItem, ConservationStatusKey, UserInfo, UseThemeResult, ThemeConfig, ThemeLocale};
 

--- a/common-ui/src/util/runtimeConfig.ts
+++ b/common-ui/src/util/runtimeConfig.ts
@@ -1,0 +1,31 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Runtime configuration accessor.
+ *
+ * Vite bakes `import.meta.env.VITE_*` at BUILD time, so a prebuilt SPA artifact cannot be
+ * re-pointed at a different portal without rebuilding. To restore the legacy "isolated
+ * branding" operative — where a portal consumes a shared, prebuilt app and supplies only its
+ * own config — we read selected keys at RUNTIME from `window.APP_CONFIG`, which is set by an
+ * un-hashed `public/config.js` (emitted at the site root and overwritable per deployment with
+ * no rebuild). Falls back to the build-time value when the key is absent.
+ *
+ * Currently used only for the theme pointer (VITE_THEME_CONFIG_URL); designed to extend to the
+ * full per-portal config set later (see SPEC.md, Layer 2).
+ */
+declare global {
+    interface Window {
+        APP_CONFIG?: Record<string, string>;
+    }
+}
+
+export function getRuntimeConfig(key: string, fallback: string): string {
+    if (typeof window !== 'undefined' && window.APP_CONFIG && window.APP_CONFIG[key] != null) {
+        return window.APP_CONFIG[key];
+    }
+    return fallback;
+}

--- a/common-ui/src/util/theme.ts
+++ b/common-ui/src/util/theme.ts
@@ -1,0 +1,74 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+/**
+ * Runtime theme configuration.
+ *
+ * A theme is a static `theme.json` manifest (hostable on e.g. GitHub Pages) that points to
+ * all the brandable assets of an atlas-index UI: CSS, header/footer Mustache templates,
+ * logo and (for future use) the available locales. UIs fetch it at startup via the
+ * `VITE_THEME_CONFIG_URL` env var, so an organisation can re-skin the apps without a rebuild.
+ *
+ * Locale switching is declared here for forward-compatibility but is NOT yet consumed by the
+ * minimal {@link useTheme} hook (see SPEC.md "Deferred" section).
+ */
+export interface ThemeLocale {
+    code: string; // e.g. "en", "es", "fr"
+    label: string; // e.g. "English", "Español"
+    messagesUrl: string; // URL to a Crowdin-compatible flat JSON: { "key": "translated string" }
+}
+
+export interface ThemeConfig {
+    cssUrls: string[]; // injected as <link> in order (delegated to injectCommonInfo)
+    jsUrls: string[]; // loaded sequentially after header HTML
+    headerUrl: string; // URL to banner.mustache
+    footerUrl: string; // URL to footer.mustache
+    logoUrl: string; // substituted for {{logoUrl}} in mustache
+    homeUrl: string; // substituted for {{homeUrl}} in mustache
+    defaultLocale: string; // e.g. "en"
+    locales: ThemeLocale[]; // list of available locales; reserved for the locale switcher
+}
+
+const THEME_CONFIG_CACHE: Map<string, ThemeConfig> = new Map();
+
+/**
+ * Fetch and cache a theme.json manifest. Falls back to `fallback` if `url` is empty or the
+ * fetch fails, so a missing/broken theme degrades to the built-in (env-var) defaults rather
+ * than breaking the app.
+ */
+export async function fetchThemeConfig(url: string, fallback: ThemeConfig): Promise<ThemeConfig> {
+    if (!url) {
+        return fallback;
+    }
+    if (THEME_CONFIG_CACHE.has(url)) {
+        return THEME_CONFIG_CACHE.get(url)!;
+    }
+    try {
+        const resp = await fetch(url);
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        const data: ThemeConfig = await resp.json();
+        THEME_CONFIG_CACHE.set(url, data);
+        return data;
+    } catch (e) {
+        console.warn(`[theme] Failed to load theme from ${url}, using fallback`, e);
+        return fallback;
+    }
+}
+
+/**
+ * Fetch locale messages (Crowdin-compatible flat JSON). Reserved for future runtime locale
+ * switching; not yet wired into {@link useTheme}.
+ */
+export async function fetchLocaleMessages(url: string): Promise<Record<string, string>> {
+    try {
+        const resp = await fetch(url);
+        if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+        return await resp.json();
+    } catch (e) {
+        console.warn(`[theme] Failed to load locale messages from ${url}`, e);
+        return {};
+    }
+}

--- a/common-ui/src/util/utils.tsx
+++ b/common-ui/src/util/utils.tsx
@@ -137,16 +137,21 @@ export function injectCommonJs(js_url: string) {
  * sanitize and replace mustache tags
  * - {{containerClass}}; value substituted
  * - {{searchServer}}{{searchPath}}; value substituted
+ * - {{logoUrl}}; value substituted (theme logo)
  * - {{loginStatus}}; braces removed
  * - {{loginURL}}; braces removed
  * - {{logoutUrl}}; braces removed
  * @param str
  */
-export function cleanMustache(str: string, containerClass: string, speciesBaseUrl?: string): string {
+export function cleanMustache(str: string, containerClass: string, speciesBaseUrl?: string, logoUrl?: string): string {
     str = str.replace(/\{\{containerClass}}/g, containerClass);
 
     if (speciesBaseUrl) {
         str = str.replace(/\{\{searchServer\}\}\{\{searchPath\}\}/g, speciesBaseUrl)
+    }
+
+    if (logoUrl) {
+        str = str.replace(/\{\{logoUrl}}/g, logoUrl);
     }
 
     // Remove all "{{" and "}}". This is messing with class selectors.

--- a/search-ui/index.html
+++ b/search-ui/index.html
@@ -12,6 +12,22 @@
     </head>
     <body>
         <div id="root"></div>
+        <!-- Runtime config: must load before the app module so window.APP_CONFIG is set first.
+             Classic (non-module) script runs ahead of the deferred module below. -->
+        <script src="/config.js"></script>
+        <!-- Apply runtime title/favicon immediately (no rebuild needed to rebrand them). -->
+        <script>
+            (function () {
+                var c = window.APP_CONFIG || {};
+                if (c.APP_TITLE) document.title = c.APP_TITLE;
+                if (c.APP_FAVICON_URL) {
+                    var link = document.querySelector('link[rel="shortcut icon"], link[rel="icon"]')
+                        || document.head.appendChild(document.createElement('link'));
+                    link.rel = 'shortcut icon';
+                    link.href = c.APP_FAVICON_URL;
+                }
+            })();
+        </script>
         <script type="module" src="/src/main.tsx"></script>
     </body>
 </html>

--- a/search-ui/public/config.js
+++ b/search-ui/public/config.js
@@ -1,0 +1,1 @@
+window.APP_CONFIG = {};

--- a/search-ui/src/App.tsx
+++ b/search-ui/src/App.tsx
@@ -4,10 +4,11 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/.
  */
 
-import {Banner, Breadcrumb, Breadcrumbs, Footer, Header, injectCommonInfo, NotFound,} from '@ala/common-ui';
+import {Banner, Breadcrumb, Breadcrumbs, Footer, Header, getRuntimeConfig, NotFound, useTheme,} from '@ala/common-ui';
 import React, {useEffect, useState} from 'react';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import buildInfo from './buildInfo.json';
+import {ALA_DEFAULT_THEME} from './config/alaDefaultTheme';
 import Search from './views/Search.tsx';
 import Species from './views/Species';
 import 'react-bootstrap-typeahead/css/Typeahead.css';
@@ -28,7 +29,14 @@ const SearchRedirect: React.FC = () => {
 
 const App: React.FC = () => {
     const [isLoggedIn, setIsLoggedIn] = useState<boolean>(isLoggedInInitial);
-    const [cssLoaded, setCssLoaded] = useState<boolean>(false);
+    const {cssLoaded, themeConfig} = useTheme({
+        // Runtime pointer (window.APP_CONFIG via /config.js) so a prebuilt app can be branded
+        // per portal with no rebuild; falls back to the build-time VITE_ value.
+        themeConfigUrl: getRuntimeConfig('VITE_THEME_CONFIG_URL', import.meta.env.VITE_THEME_CONFIG_URL ?? ''),
+        fallbackTheme: ALA_DEFAULT_THEME,
+        buildInfo,
+        env: import.meta.env.VITE_ENV,
+    });
     const [breadcrumbs, setBreadcrumbs] = useState<Breadcrumb[]>([
         {title: 'Home', href: import.meta.env.VITE_HOME_URL},
         {title: 'Search', href: '/'},
@@ -40,15 +48,6 @@ const App: React.FC = () => {
             setIsMobile(window.innerWidth <= MOBILE_BREAKPOINT);
         window.addEventListener('resize', handleResize);
         return () => window.removeEventListener('resize', handleResize);
-    }, []);
-
-    useEffect(() => {
-        injectCommonInfo(
-            buildInfo,
-            import.meta.env.VITE_ENV,
-            import.meta.env.VITE_COMMON_CSS,
-            setCssLoaded
-        );
     }, []);
 
     // when receiving a login URL, handle the login by setting the auth cookie only
@@ -79,10 +78,11 @@ const App: React.FC = () => {
             isLoggedIn={isLoggedIn}
             logoutFn={handleLogout}
             loginFn={handleLogin}
-            headerUrl={import.meta.env.VITE_COMMON_HEADER_HTML}
+            headerUrl={themeConfig?.headerUrl ?? import.meta.env.VITE_COMMON_HEADER_HTML}
             searchBaseUrl={import.meta.env.VITE_SEARCH_URL_PREFIX}
-            jsUrl={import.meta.env.VITE_COMMON_JS}
+            jsUrl={themeConfig?.jsUrls.join(',') ?? import.meta.env.VITE_COMMON_JS}
             containerClass={import.meta.env.VITE_COMMON_CONTAINER_CLASS}
+            logoUrl={themeConfig?.logoUrl}
         />
 
         <Breadcrumbs breadcrumbs={breadcrumbs}/>
@@ -106,7 +106,8 @@ const App: React.FC = () => {
             isLoggedIn={isLoggedIn}
             logoutFn={handleLogout}
             loginFn={handleLogin}
-            footerUrl={import.meta.env.VITE_COMMON_FOOTER_HTML}
+            footerUrl={themeConfig?.footerUrl ?? import.meta.env.VITE_COMMON_FOOTER_HTML}
+            logoUrl={themeConfig?.logoUrl}
         />
     </>;
 };

--- a/search-ui/src/components/search/examples.tsx
+++ b/search-ui/src/components/search/examples.tsx
@@ -56,7 +56,7 @@ export function Examples({asText, tab, setQueryAndTab}: ExampleProps): React.Rea
                 {asText ? (
                     <>
                         <a onClick={() => setQueryAndTab(example.query, example.tab)}
-                           style={{textDecoration: 'underline', color: '#212121', cursor: 'pointer'}}>
+                           style={{textDecoration: 'underline', color: 'var(--ala-text, #212121)', cursor: 'pointer'}}>
                             {example.query}
                         </a>
                         {i < examples.length - 1 && <>,&nbsp;</>}

--- a/search-ui/src/components/search/genericView.tsx
+++ b/search-ui/src/components/search/genericView.tsx
@@ -324,14 +324,14 @@ function GenericView({queryString, props, isMobile,}: GenericProps) {
                         ))}
                         {facet.lessNumber && facet.items.length > facet.lessNumber && (
                             facet.more ?
-                                <div onClick={() => {facet.more = false;setFacets([...facets]);}} style={{marginTop: '8px', color: '#c44d34'}}>
+                                <div onClick={() => {facet.more = false;setFacets([...facets]);}} style={{marginTop: '8px', color: 'var(--ala-secondary, #c44d34)'}}>
                                     <FontAwesomeIconLite icon={faCaretUp} size="14" style={{marginRight: '8px'}}/>
                                     <span className={classes.refineItem}>
                                         Show less
                                     </span>
                                 </div>
                                 :
-                                <div onClick={() => {facet.more = true;setFacets([...facets]);}} style={{marginTop: '8px', color: '#c44d34'}}>
+                                <div onClick={() => {facet.more = true;setFacets([...facets]);}} style={{marginTop: '8px', color: 'var(--ala-secondary, #c44d34)'}}>
                                     <FontAwesomeIconLite icon={faCaretDown} size="14" style={{marginRight: '8px'}}/>
                                     <span className={classes.refineItem}>
                                         Show more

--- a/search-ui/src/components/search/landingPage.tsx
+++ b/search-ui/src/components/search/landingPage.tsx
@@ -33,7 +33,7 @@ function LandingPage({isMobile}: { isMobile: boolean }) {
     };
 
     return <div style={{maxWidth: '1200px', marginLeft: 'auto', marginRight: 'auto', marginTop: (isMobile ? '20px' : '120px')}} >
-        <div style={{fontFamily: 'Roboto', fontWeight: '600', fontSize: '26px', lineHeight: '32px', color: '#C44D34', textAlign: (isMobile ? 'left' : 'center')}}>
+        <div style={{fontFamily: 'Roboto', fontWeight: '600', fontSize: '26px', lineHeight: '32px', color: 'var(--ala-secondary, #C44D34)', textAlign: (isMobile ? 'left' : 'center')}}>
             Featured pages</div>
         <div className="row" style={{marginTop: '30px'}}>
             {featuredPages && featuredPages.map((item: any, index: number) => (

--- a/search-ui/src/components/search/props/speciesDefn.tsx
+++ b/search-ui/src/components/search/props/speciesDefn.tsx
@@ -305,7 +305,7 @@ export const speciesDefn: GenericViewProps = {
             </>,
             description: <>
                 {matchInfo(item, searchTerm || '') != null &&
-                    <span className={classes.overflowText} style={{fontStyle: 'italic', color: '#212121', paddingBottom: '5px'}}>
+                    <span className={classes.overflowText} style={{fontStyle: 'italic', color: 'var(--ala-text, #212121)', paddingBottom: '5px'}}>
                         {matchInfo(item, searchTerm || '')}
                     </span>
                 }
@@ -353,7 +353,7 @@ export const speciesDefn: GenericViewProps = {
                 </span>
                 <div style={{height: '13px'}}/>
                 {matchInfo(item, searchTerm || '') != null &&
-                    <span className={classes.listItemText} style={{fontStyle: 'italic', color: '#212121'}}>
+                    <span className={classes.listItemText} style={{fontStyle: 'italic', color: 'var(--ala-text, #212121)'}}>
                         {matchInfo(item, searchTerm || '')}
                     </span>
                 }

--- a/search-ui/src/components/search/search.module.css
+++ b/search-ui/src/components/search/search.module.css
@@ -28,7 +28,7 @@
     width: 50px;
     height: 47px;
     border-radius: 0px 5px 5px 0px;
-    background: #c44d34;
+    background: var(--ala-secondary, #c44d34);
     border: 1px solid #637073;
     cursor: pointer;
     transform: none;
@@ -40,7 +40,7 @@
 }
 
 .searchButton:active {
-    background: #212121 !important;
+    background: var(--ala-text, #212121) !important;
 }
 
 .mobileSelect {
@@ -65,7 +65,7 @@
 }
 
 .searchTitle {
-    color: #212121;
+    color: var(--ala-text, #212121);
     text-align: center;
 
     font-family: Roboto;
@@ -90,13 +90,13 @@
 }
 
 .activeTab {
-    border-bottom: 2px solid #c44d34 !important;
-    color: #c44d34;
+    border-bottom: 2px solid var(--ala-secondary, #c44d34) !important;
+    color: var(--ala-secondary, #c44d34);
 }
 
 .tabButtons:hover {
-    border-bottom: 2px solid #c44d34;
-    color: #c44d34;
+    border-bottom: 2px solid var(--ala-secondary, #c44d34);
+    color: var(--ala-secondary, #c44d34);
 }
 
 .tabButtons {
@@ -157,7 +157,7 @@
 }
 
 .groupName {
-    color: #c44d34;
+    color: var(--ala-secondary, #c44d34);
 
     /* Desktop/H4/Semibold */
     font-family: Roboto;
@@ -175,7 +175,7 @@
 }
 
 .listItemName {
-    color: #003a70;
+    color: var(--ala-link, #003a70);
 
     /* Desktop/Body/Semibold italic underline */
     font-size: 16px;
@@ -222,7 +222,7 @@
 .filterButton,
 .filterButton:hover,
 .filterButton:active {
-    color: #212121;
+    color: var(--ala-text, #212121);
     transform: none !important;
     height: 38px;
     padding-left: 10px;
@@ -319,7 +319,7 @@
 }
 
 .refineTitle {
-    color: #212121;
+    color: var(--ala-text, #212121);
 
     /* Desktop/Intro/Semibold */
     font-family: Roboto;
@@ -337,7 +337,7 @@
 }
 
 .resultsTitle {
-    color: #212121;
+    color: var(--ala-text, #212121);
 
     /* Desktop/Intro/Reg */
     font-family: Roboto;
@@ -348,7 +348,7 @@
 }
 
 .resultsTitleBold {
-    color: #212121;
+    color: var(--ala-text, #212121);
 
     /* Desktop/Intro/Reg */
     font-family: Roboto;
@@ -359,7 +359,7 @@
 }
 
 .resultsTitleItalic {
-    color: #212121;
+    color: var(--ala-text, #212121);
 
     /* Desktop/Intro/Reg */
     font-family: Roboto;
@@ -385,7 +385,7 @@
 }
 
 .topResult {
-    color: #212121;
+    color: var(--ala-text, #212121);
 
     /* Desktop/Body/Semibold */
     font-family: Roboto;
@@ -408,13 +408,13 @@
 }
 
 .alaSelect div input {
-    border: 1px solid #212121;
+    border: 1px solid var(--ala-text, #212121);
     border-radius: 5px;
     height: 38px;
 }
 
 .alaSelect div svg {
-    color: #212121;
+    color: var(--ala-text, #212121);
     height: 16px !important;
     width: 16px !important;
 }
@@ -427,20 +427,20 @@
     }
 
     .alaSelect div input {
-        border: 1px solid #212121;
+        border: 1px solid var(--ala-text, #212121);
         border-radius: 5px;
         height: 32px;
     }
 
     .alaSelect div svg {
-        color: #212121;
+        color: var(--ala-text, #212121);
         height: 14px !important;
         width: 14px !important;
     }
 }
 
 .refineSectionTitle {
-    color: #c44d34 !important;
+    color: var(--ala-secondary, #c44d34) !important;
 
     /* Desktop/Body/Semibold */
     font-family: Roboto;
@@ -479,7 +479,7 @@
     height: 38px;
     background-color: #f2f2f2;
     padding: 8px 19px 10px 19px;
-    color: #212121;
+    color: var(--ala-text, #212121);
     border: 1px solid #f2f2f2;
     border-radius: 4px;
     flex-shrink: 0;
@@ -493,7 +493,7 @@
         height: 32px;
         background-color: #f2f2f2;
         padding: 8px 15px 8px 15px;
-        color: #212121;
+        color: var(--ala-text, #212121);
         border: 1px solid #f2f2f2;
         border-radius: 4px;
         flex-shrink: 0;
@@ -507,16 +507,16 @@
 }
 
 .activeFilter {
-    color: #212121;
+    color: var(--ala-text, #212121);
     transform: none;
-    border: 1px solid #212121;
+    border: 1px solid var(--ala-text, #212121);
     background-color: white;
     flex-shrink: 0;
     white-space: nowrap;
 }
 
 .groupCount {
-    color: #003a70;
+    color: var(--ala-link, #003a70);
     font-weight: 500;
     line-height: 22px;
     font-size: 16px;
@@ -524,7 +524,7 @@
 }
 
 .groupCount:hover {
-    color: #c44d34;
+    color: var(--ala-secondary, #c44d34);
 }
 
 @media (max-width: 768px) {
@@ -617,7 +617,7 @@
 
 .refineResultsBtn {
     background-color: #ffffff;
-    border: 1px solid #212121;
+    border: 1px solid var(--ala-text, #212121);
     border-radius: 20px;
 
     font-size: 12px;
@@ -632,6 +632,6 @@
 }
 
 .refineDialog {
-    border: 1px solid #212121;
+    border: 1px solid var(--ala-text, #212121);
     border-radius: 5px;
 }

--- a/search-ui/src/components/species/disambiguationView.tsx
+++ b/search-ui/src/components/species/disambiguationView.tsx
@@ -203,7 +203,7 @@ function DisambiguationView({result, isMobile}: DisambiguationViewProps) {
                     <tr key={idx}>
                         <td>
                             <a href={`/species/${row.guid}`}
-                               style={{color: '#003A70', textDecoration: 'underline'}}
+                               style={{color: 'var(--ala-link, #003A70)', textDecoration: 'underline'}}
                                dangerouslySetInnerHTML={{__html: row.nameFormatted}}/>
                             <div style={{
                                 fontSize: '0.85em',
@@ -219,7 +219,7 @@ function DisambiguationView({result, isMobile}: DisambiguationViewProps) {
                             {row.matchTypeDetailName && <>
                                 {': '}
                                 <a href={`/species/${encodeURIComponent(row.matchTypeDetailName)}`}
-                                   style={{color: '#003A70', textDecoration: 'underline'}}>
+                                   style={{color: 'var(--ala-link, #003A70)', textDecoration: 'underline'}}>
                                     {row.matchTypeDetailName}
                                 </a>
                             </>}

--- a/search-ui/src/components/species/namesView.tsx
+++ b/search-ui/src/components/species/namesView.tsx
@@ -57,7 +57,7 @@ function NamesView({result, isMobile}: MapViewProps) {
                         </>)}
                     </td>
                     <td>
-                        <a href={result?.source} style={{color: '#003A70', textDecoration: 'underline'}}>
+                        <a href={result?.source} style={{color: 'var(--ala-link, #003A70)', textDecoration: 'underline'}}>
                             {result?.datasetName}
                         </a>
                     </td>
@@ -82,7 +82,7 @@ function NamesView({result, isMobile}: MapViewProps) {
                                 {item?.source ? (
                                     <a href={item?.source}
                                        dangerouslySetInnerHTML={{__html: item.nameFormatted}}
-                                       style={{textDecoration: 'underline', color: '#003A70'}}/>
+                                       style={{textDecoration: 'underline', color: 'var(--ala-link, #003A70)'}}/>
                                 ) : (
                                     <span dangerouslySetInnerHTML={{__html: item.nameFormatted}}/>
                                 )}
@@ -99,7 +99,7 @@ function NamesView({result, isMobile}: MapViewProps) {
                             </td>
                             <td>
                                 {item?.source ? (
-                                    <a href={item?.source} style={{textDecoration: 'underline', color: '#003A70'}}>
+                                    <a href={item?.source} style={{textDecoration: 'underline', color: 'var(--ala-link, #003A70)'}}>
                                         {item?.datasetName || 'Link'}</a>
                                 ) : (<span>{item?.datasetName}</span>)}
                             </td>
@@ -126,7 +126,7 @@ function NamesView({result, isMobile}: MapViewProps) {
                                 {item?.source ? (
                                     <a href={item?.source}
                                        dangerouslySetInnerHTML={{__html: item.nameFormatted}}
-                                       style={{textDecoration: 'underline', color: '#003A70'}}/>
+                                       style={{textDecoration: 'underline', color: 'var(--ala-link, #003A70)'}}/>
                                 ) : (
                                     <span dangerouslySetInnerHTML={{__html: item.nameFormatted}}/>
                                 )}
@@ -143,7 +143,7 @@ function NamesView({result, isMobile}: MapViewProps) {
                             </td>
                             <td>
                                 {item?.source ? (
-                                    <a href={item?.source} style={{textDecoration: 'underline', color: '#003A70'}}>
+                                    <a href={item?.source} style={{textDecoration: 'underline', color: 'var(--ala-link, #003A70)'}}>
                                         {item?.datasetName || 'Link'}</a>
                                 ) : (<span>{item?.datasetName}</span>)}
                             </td>
@@ -176,7 +176,7 @@ function NamesView({result, isMobile}: MapViewProps) {
                         <tr key={idx}>
                             <td>
                                 {item?.source ? (
-                                    <a href={item?.source} style={{textDecoration: 'underline', color: '#003A70'}}>
+                                    <a href={item?.source} style={{textDecoration: 'underline', color: 'var(--ala-link, #003A70)'}}>
                                         {item?.guid}
                                     </a>
                                 ) : (
@@ -196,7 +196,7 @@ function NamesView({result, isMobile}: MapViewProps) {
                                 {item?.source ? (
                                     <a href={item?.source} style={{
                                         textDecoration: 'underline',
-                                        color: '#003A70'
+                                        color: 'var(--ala-link, #003A70)'
                                     }}>{item?.datasetName || 'Link'}</a>
                                 ) : (
                                     <span>{item?.datasetName}</span>
@@ -238,7 +238,7 @@ function NamesView({result, isMobile}: MapViewProps) {
                             <td>
                                 {item?.source ? (
                                     <a href={item?.source}
-                                       style={{textDecoration: 'underline', color: '#003A70'}}>{item?.name}</a>
+                                       style={{textDecoration: 'underline', color: 'var(--ala-link, #003A70)'}}>{item?.name}</a>
                                 ) : (
                                     <span>{item.name}</span>
                                 )}
@@ -256,7 +256,7 @@ function NamesView({result, isMobile}: MapViewProps) {
                             <td>
                                 {item?.source ? (
                                     <a href={item?.source} style={{
-                                        textDecoration: 'underline', color: '#003A70'
+                                        textDecoration: 'underline', color: 'var(--ala-link, #003A70)'
                                     }}>{item?.datasetName || 'Link'}</a>
                                 ) : (
                                     <span>{item?.datasetName}</span>
@@ -289,7 +289,7 @@ function NamesView({result, isMobile}: MapViewProps) {
                         Australian Institute of Aboriginal and
                         Torres Strait Islander Studies (
                         <a href="https://aiatsis.gov.au" target="_blank"
-                           style={{color: '#003A70', textDecoration: 'underline'}}>
+                           style={{color: 'var(--ala-link, #003A70)', textDecoration: 'underline'}}>
                             AIATSIS
                         </a>) information about the language.
                     </>}
@@ -309,7 +309,7 @@ function NamesView({result, isMobile}: MapViewProps) {
                             <td>
                                 {item?.source ? (
                                     <a href={item?.source}
-                                       style={{color: '#003A70', textDecoration: 'underline'}}>{item?.name}</a>
+                                       style={{color: 'var(--ala-link, #003A70)', textDecoration: 'underline'}}>{item?.name}</a>
                                 ) : (
                                     <span>{item.name}</span>
                                 )}
@@ -324,7 +324,7 @@ function NamesView({result, isMobile}: MapViewProps) {
                             </td>
                             <td>
                                 {item?.languageURL ? (
-                                    <a href={item?.languageURL} style={{color: '#003A70', textDecoration: 'underline'}}>
+                                    <a href={item?.languageURL} style={{color: 'var(--ala-link, #003A70)', textDecoration: 'underline'}}>
                                         {item?.languageName || item?.language}</a>
                                 ) : (
                                     <span>{item?.languageName || item?.language}</span>

--- a/search-ui/src/components/species/resourcesView.tsx
+++ b/search-ui/src/components/species/resourcesView.tsx
@@ -211,7 +211,7 @@ function ResourcesView({result, isMobile}: MapViewProps) {
             </span>
             <table className="table table-striped align-middle" style={{
                 marginTop: '20px',
-                borderTop: '0.5px solid #212121',
+                borderTop: '0.5px solid var(--ala-text, #212121)',
                 paddingTop: '10px',
                 paddingBottom: '10px'
             }}>
@@ -236,7 +236,7 @@ function ResourcesView({result, isMobile}: MapViewProps) {
                                 {resource.Authors?.length > 0 && ', '}
                                 <span style={{fontStyle: resource.ItemUrl ? 'italic' : undefined}}>
                                     <a href={resource.PartUrl || resource.ItemUrl} style={{
-                                        color: '#003A70',
+                                        color: 'var(--ala-link, #003A70)',
                                         textDecoration: 'underline'
                                     }}>'{resource.Title}'</a>
                                 </span>

--- a/search-ui/src/components/species/species.module.css
+++ b/search-ui/src/components/species/species.module.css
@@ -39,14 +39,14 @@
 
 .speciesSectionText a,
 .traitsSectionText a {
-    color: #003a70;
+    color: var(--ala-link, #003A70);
     &:hover {
         color: #1b5e83;
     }
 }
 
 .speciesSectionText {
-    color: #212121;
+    color: var(--ala-text, #212121);
 
     font-size: 16px;
     line-height: 24px;
@@ -122,7 +122,7 @@
     width: 50px;
     height: 47px;
     border-radius: 0px 5px 5px 0px;
-    background: #c44d34;
+    background: var(--ala-secondary, #C44D34);
     border: 1px solid #637073;
     cursor: pointer;
     transform: none;
@@ -134,11 +134,11 @@
 }
 
 .searchButton:active {
-    background: #212121 !important;
+    background: var(--ala-text, #212121) !important;
 }
 
 .searchTitle {
-    color: #212121;
+    color: var(--ala-text, #212121);
     text-align: center;
     text-shadow: 0px 4px 4px rgba(0, 0, 0, 0.25);
 
@@ -156,13 +156,13 @@
 }
 
 .activeTab {
-    border-bottom: 2px solid #c44d34;
-    color: #c44d34;
+    border-bottom: 2px solid var(--ala-secondary, #C44D34);
+    color: var(--ala-secondary, #C44D34);
 }
 
 .tabButtons:hover {
-    border-bottom: 2px solid #c44d34;
-    color: #c44d34;
+    border-bottom: 2px solid var(--ala-secondary, #C44D34);
+    color: var(--ala-secondary, #C44D34);
 }
 
 .tabButtons {
@@ -189,7 +189,7 @@
     font-weight: 600;
     font-size: 32px; /*52px;*/
     line-height: 40px; /*58px;*/
-    color: #212121;
+    color: var(--ala-text, #212121);
     display: block;
     overflow-wrap: anywhere;
 }
@@ -238,7 +238,7 @@
 
 .speciesSectionText a,
 .traitsSectionText a {
-    color: #003a70;
+    color: var(--ala-link, #003A70);
     &:hover {
         color: #1b5e83;
     }
@@ -362,7 +362,7 @@
     font-size: 14px;
     line-height: 20px;
     text-decoration-line: underline;
-    color: #003a70;
+    color: var(--ala-link, #003A70);
     cursor: pointer;
 }
 
@@ -467,7 +467,7 @@
 }
 
 .refineSectionTitle {
-    color: #c44d34 !important;
+    color: var(--ala-secondary, #C44D34) !important;
     font-size: 16px;
     font-style: normal;
     font-weight: 600;
@@ -496,22 +496,22 @@
 
 .mapRadio {
     background-color: #fff;
-    border-color: #212121 !important;
+    border-color: var(--ala-text, #212121) !important;
     cursor: pointer;
 }
 
 .mapRadio:checked {
-    background-color: #212121 !important;
-    border-color: #212121 !important;
+    background-color: var(--ala-text, #212121) !important;
+    border-color: var(--ala-text, #212121) !important;
 }
 
 .mapRadio:focus {
     box-shadow: none !important;
-    border-color: #212121 !important;
+    border-color: var(--ala-text, #212121) !important;
 }
 
 .resultsTitle {
-    color: #212121;
+    color: var(--ala-text, #212121);
     font-size: 20px;
     font-style: normal;
     font-weight: 400;
@@ -519,7 +519,7 @@
 }
 
 .resultsTitleBold {
-    color: #212121;
+    color: var(--ala-text, #212121);
     font-size: 20px;
     font-style: normal;
     font-weight: 600;
@@ -527,7 +527,7 @@
 }
 
 .resultsTitleItalic {
-    color: #212121;
+    color: var(--ala-text, #212121);
     font-size: 20px;
     font-style: italic;
     font-weight: 400;
@@ -585,13 +585,13 @@
 }
 
 .alaSelect div input {
-    border: 1px solid #212121;
+    border: 1px solid var(--ala-text, #212121);
     border-radius: 5px;
     height: 38px;
 }
 
 .alaSelect div svg {
-    color: #212121;
+    color: var(--ala-text, #212121);
     height: 16px !important;
     width: 16px !important;
 }
@@ -604,13 +604,13 @@
     }
 
     .alaSelect div input {
-        border: 1px solid #212121;
+        border: 1px solid var(--ala-text, #212121);
         border-radius: 5px;
         height: 32px;
     }
 
     .alaSelect div svg {
-        color: #212121;
+        color: var(--ala-text, #212121);
         height: 14px !important;
         width: 14px !important;
     }
@@ -668,7 +668,7 @@
     font-size: 22px;
     line-height: 28px;
 
-    color: #C44D34;
+    color: var(--ala-secondary, #C44D34);
 }
 
 .mobileSectionContent {

--- a/search-ui/src/config/alaDefaultTheme.ts
+++ b/search-ui/src/config/alaDefaultTheme.ts
@@ -1,0 +1,23 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/.
+ */
+
+import type {ThemeConfig} from '@ala/common-ui';
+
+/**
+ * Built-in fallback theme, derived from the existing VITE_* env vars. Used whenever
+ * VITE_THEME_CONFIG_URL is unset or its manifest fails to load, so behaviour is identical to
+ * the pre-theme code path.
+ */
+export const ALA_DEFAULT_THEME: ThemeConfig = {
+    cssUrls: [import.meta.env.VITE_COMMON_CSS ?? ''],
+    jsUrls: [import.meta.env.VITE_COMMON_JS ?? ''],
+    headerUrl: import.meta.env.VITE_COMMON_HEADER_HTML ?? '',
+    footerUrl: import.meta.env.VITE_COMMON_FOOTER_HTML ?? '',
+    logoUrl: import.meta.env.VITE_LOGO_URL ?? 'https://www.ala.org.au/app/uploads/2019/01/logo.png',
+    homeUrl: import.meta.env.VITE_HOME_URL ?? '/',
+    defaultLocale: 'en',
+    locales: [{code: 'en', label: 'English', messagesUrl: ''}],
+};

--- a/search-ui/src/css/search.css
+++ b/search-ui/src/css/search.css
@@ -655,7 +655,7 @@ facet-item {
 .facet-item,
 .multipleFacetsLink,
 .dqLabel {
-    color: #c44d34;
+    color: var(--ala-secondary, #c44d34);
     cursor: pointer;
 }
 
@@ -1245,7 +1245,7 @@ body {
     font-family: 'Roboto', sans-serif;
     font-size: 14px;
     line-height: 1.428571429;
-    color: #212121;
+    color: var(--ala-text, #212121);
     background-color: #fff;
 }
 
@@ -1339,7 +1339,7 @@ section#breadcrumb {
     padding-top: 14px;
     background-color: #f2f2f2;
     font-weight: 400;
-    color: #212121;
+    color: var(--ala-text, #212121);
 }
 
 section#breadcrumb li + li::before {
@@ -1354,7 +1354,7 @@ section#breadcrumb li + li::before {
 
 .breadcrumb-item a,
 .breadcrumb-item a:hover {
-    color: #212121;
+    color: var(--ala-text, #212121);
 }
 
 .breadcrumb-list {
@@ -1396,10 +1396,10 @@ section#breadcrumb li + li::before {
     background-color: #9d9d9d;
 }
 .color--dark-red {
-    color: #c44d34;
+    color: var(--ala-secondary, #c44d34);
 }
 .backgroundcolor--dark-red {
-    background-color: #c44d34;
+    background-color: var(--ala-secondary, #c44d34);
 }
 .color--green {
     color: #006435;
@@ -1426,10 +1426,10 @@ section#breadcrumb li + li::before {
     background-color: #df3034;
 }
 .color--off-black {
-    color: #212121;
+    color: var(--ala-text, #212121);
 }
 .backgroundcolor--off-black {
-    background-color: #212121;
+    background-color: var(--ala-text, #212121);
 }
 .color--off-white {
     color: #f2f2f2;
@@ -1444,10 +1444,10 @@ section#breadcrumb li + li::before {
     background-color: #d0367d;
 }
 .color--primary-red {
-    color: #f26649;
+    color: var(--ala-primary, #f26649);
 }
 .backgroundcolor--primary-red {
-    background-color: #f26649;
+    background-color: var(--ala-primary, #f26649);
 }
 .color--purple {
     color: #2e358b;
@@ -1480,16 +1480,16 @@ section#breadcrumb li + li::before {
     background-color: #65b044;
 }
 .color--flamingo {
-    color: #f26649;
+    color: var(--ala-primary, #f26649);
 }
 .backgroundcolor--flamingo {
-    background-color: #f26649;
+    background-color: var(--ala-primary, #f26649);
 }
 .color--mojo {
-    color: #c44d34;
+    color: var(--ala-secondary, #c44d34);
 }
 .backgroundcolor--mojo {
-    background-color: #c44d34;
+    background-color: var(--ala-secondary, #c44d34);
 }
 .color-lochmara {
     color: #0087be;
@@ -1505,7 +1505,7 @@ section#breadcrumb li + li::before {
 }
 
 a {
-    color: #c44d34;
+    color: var(--ala-secondary, #c44d34);
     text-decoration: none;
 }
 
@@ -1523,8 +1523,8 @@ a:hover {
 .btn-primary,
 .gform_button {
     color: #fff;
-    background-color: #c44d34;
-    border-color: #c44d34;
+    background-color: var(--ala-secondary, #c44d34);
+    border-color: var(--ala-secondary, #c44d34);
 }
 
 .btn-primary:hover {
@@ -1575,7 +1575,7 @@ nav {
     border-color: #bbb;
     border-bottom: 1px solid #999;
     margin-right: 5px;
-    color: #c44d34;
+    color: var(--ala-secondary, #c44d34);
 }
 
 .nav-tabs .nav-link:hover {
@@ -1746,7 +1746,7 @@ h4,
 }
 
 .speciesPage {
-    color: #212121;
+    color: var(--ala-text, #212121);
 }
 
 #speciesListHeader {
@@ -1784,7 +1784,7 @@ h4,
     font-weight: 400;
     line-height: 18px;
     text-align: left;
-    color: #003a70;
+    color: var(--ala-link, #003a70);
     text-decoration: underline;
 }
 
@@ -1827,7 +1827,7 @@ h4,
 
 .speciesInvasiveLink {
     text-decoration: underline;
-    color: #003a70;
+    color: var(--ala-link, #003a70);
 }
 
 .speciesInvasiveFlag {
@@ -1904,8 +1904,8 @@ h4,
     border-left: 0;
     border-right: 0;
     border-top: 0;
-    border-bottom: 3px solid #c44d34;
-    color: #c44d34;
+    border-bottom: 3px solid var(--ala-secondary, #c44d34);
+    color: var(--ala-secondary, #c44d34);
 
     font-size: 14px;
     font-weight: 600;
@@ -1924,7 +1924,7 @@ h4,
 }
 
 .speciesPage .nav-tabs .nav-link {
-    color: #212121;
+    color: var(--ala-text, #212121);
     padding: 15px 15px 16px 15px;
 }
 
@@ -1994,7 +1994,7 @@ h4,
 
 .speciesMapButton {
     padding: 10px 14px 15px 14px;
-    border: 1px solid #c44d34;
+    border: 1px solid var(--ala-secondary, #c44d34);
     width: 255px;
     border-radius: 5px;
     height: 69px;
@@ -2006,7 +2006,7 @@ h4,
 }
 
 .species-red {
-    color: #c44d34;
+    color: var(--ala-secondary, #c44d34);
     font-size: 25px;
     margin-top: -2px;
     margin-right: -5px;
@@ -2089,7 +2089,7 @@ h4,
 
 .speciesMapControlRefresh {
     border-radius: 20px;
-    border: 1px solid #212121;
+    border: 1px solid var(--ala-text, #212121);
 
     font-size: 16px;
     font-weight: 500;
@@ -2129,7 +2129,7 @@ h4,
     line-height: 22px;
     text-align: left;
 
-    color: #003a70;
+    color: var(--ala-link, #003a70);
     text-decoration: underline;
 
     position: absolute;
@@ -2216,7 +2216,7 @@ h4,
 
 .speciesDescription a,
 .speciesDescription a:hover {
-    color: #003a70;
+    color: var(--ala-link, #003a70);
 }
 
 .speciesImagesBlock {
@@ -2257,9 +2257,9 @@ h4,
 }
 
 .speciesImageBtnSelected {
-    background-color: #212121;
+    background-color: var(--ala-text, #212121);
     color: white;
-    border-color: #212121;
+    border-color: var(--ala-text, #212121);
 
     border-radius: 5px;
 
@@ -2275,9 +2275,9 @@ h4,
 }
 
 .speciesImageBtnSelected:hover {
-    background-color: #212121;
+    background-color: var(--ala-text, #212121);
     color: white;
-    border-color: #212121;
+    border-color: var(--ala-text, #212121);
 }
 
 .speciesImageBtn:hover {
@@ -2314,7 +2314,7 @@ h4,
 }
 
 .namesLink {
-    color: #003a70;
+    color: var(--ala-link, #003a70);
     text-decoration: underline;
 }
 
@@ -2353,7 +2353,7 @@ h4,
 
 .namesRowHeader {
     height: 32px;
-    border-bottom: 0.5px solid #212121;
+    border-bottom: 0.5px solid var(--ala-text, #212121);
     margin-top: 30px;
     padding-bottom: 10px;
 }
@@ -2378,7 +2378,7 @@ h4,
 
 .speciesPage a:not(.btn),
 .speciesPage a:hover:not(.btn) {
-    color: #003a70;
+    color: var(--ala-link, #003a70);
     text-decoration: underline;
 }
 
@@ -2548,9 +2548,9 @@ h4,
 
 .traitsButtonCsv,
 .traitsButtonCsv:hover {
-    background-color: #212121;
+    background-color: var(--ala-text, #212121);
     color: white;
-    border-color: #212121;
+    border-color: var(--ala-text, #212121);
 
     border-radius: 5px;
 

--- a/search-ui/src/index.css
+++ b/search-ui/src/index.css
@@ -1,10 +1,17 @@
+/* Brand colours via CSS custom properties with inline fallbacks: var(--ala-x, <hex>).
+   The hex is the default; a runtime theme re-skins the UI with no rebuild simply by declaring
+   :root { --ala-* } in its CSS. We deliberately DO NOT declare :root{--ala-*} here, because
+   injectCommonInfo inserts the theme CSS at the top of <head> (so app CSS wins by order); an
+   app-level :root would then defeat the theme's :root. Inline fallbacks are order-independent.
+   See SPEC.md "Runtime Configurable Themes". */
+
 .btn.ala-btn-primary {
     position: relative;
     padding: 10px 40px 10px 14px;
     background: #ffffff;
-    border: 1px solid #c44d34;
+    border: 1px solid var(--ala-secondary, #c44d34);
     border-radius: 5px;
-    color: #212121;
+    color: var(--ala-text, #212121);
     font-size: 16px;
     line-height: 22px;
     font-weight: 500;
@@ -27,14 +34,14 @@
 }
 
 .btn.ala-btn-primary:hover {
-    background-color: #f26649 !important;
-    border-color: #f26649 !important;
+    background-color: var(--ala-primary, #f26649) !important;
+    border-color: var(--ala-primary, #f26649) !important;
 }
 
 .btn:active.ala-btn-primary {
-    background-color: #c44d34 !important;
+    background-color: var(--ala-secondary, #c44d34) !important;
     color: #ffffff !important;
-    border-color: #c44d34 !important;
+    border-color: var(--ala-secondary, #c44d34) !important;
 }
 
 .form-select:focus {
@@ -43,7 +50,7 @@
 }
 
 .speciesPage a:not(:is(.btn, .leaflet-container a, .leaflet-container * a)) {
-    color: #003a70 !important;
+    color: var(--ala-link, #003a70) !important;
     text-decoration: underline !important;
 }
 
@@ -72,13 +79,13 @@
 }
 
 .table > tbody > tr:first-of-type > * {
-    border-top: 0.5px solid #212121 !important;
+    border-top: 0.5px solid var(--ala-text, #212121) !important;
 }
 
 .ala-btn-secondary {
     padding: 0px 20px 0px 20px !important;
     background: #ffffff !important;
-    border: 1px solid #212121 !important;
+    border: 1px solid var(--ala-text, #212121) !important;
     border-radius: 20px !important;
 
     font-weight: 500 !important;
@@ -93,7 +100,7 @@
 }
 
 .ala-btn-secondary:active {
-    background: #212121 !important;
+    background: var(--ala-text, #212121) !important;
 }
 
 @media (max-width: 768px) {

--- a/search-ui/src/views/Search.tsx
+++ b/search-ui/src/views/Search.tsx
@@ -241,7 +241,7 @@ function Search({setBreadcrumbs, isMobile}: {
                 {isMobile && <div style={{ height: '20px'}}>&nbsp;</div>}
             </div>
             {isMobile && landingPage && <div style={{ marginTop: '20px'}}>
-                <div style={{fontFamily: 'Roboto', fontWeight: '600', fontSize: '26px', lineHeight: '32px', color: '#C44D34', textAlign: 'left', marginBottom: '20px'}}>
+                <div style={{fontFamily: 'Roboto', fontWeight: '600', fontSize: '26px', lineHeight: '32px', color: 'var(--ala-secondary, #C44D34)', textAlign: 'left', marginBottom: '20px'}}>
                 Try searching for</div>
                 <Examples asText={false} tab={tab} setQueryAndTab={(query: string, tab: string | undefined) => {setLandingPage(false); setQuery(query); setTab(tab || 'all'); setSearchInputText(query); setLandingPage(false);}}/>
             </div>}

--- a/search-ui/src/vite-env.d.ts
+++ b/search-ui/src/vite-env.d.ts
@@ -1,1 +1,7 @@
 /// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+    // URL of a runtime theme.json manifest. When empty, the app falls back to ALA_DEFAULT_THEME
+    // (built from the VITE_COMMON_* / VITE_LOGO_URL env vars). See common-ui ThemeConfig.
+    readonly VITE_THEME_CONFIG_URL: string;
+}

--- a/static-server/static/testPage.html
+++ b/static-server/static/testPage.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<!-- static-server/static/testPage.html
+     Visual QA page for theme developers. Renders brand colours, buttons, typography and forms
+     so a theme can be eyeballed. Pick a theme with a single, memorable param:
+        ?theme=community     -> loads themes/community/theme.json
+        ?theme=ala           -> loads themes/ala/theme.json
+        (no param)           -> ALA baseline (common/ala-combined.css + common header/footer)
+     ?theme also accepts a full theme.json path/URL. Individual ?cssUrl/?headerUrl/?footerUrl/
+     ?logoUrl still work as one-off overrides. -->
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Theme Test Page</title>
+    <style>
+        /* Fallback brand variables — overridden by the theme CSS loaded at runtime. */
+        :root {
+            --ala-primary: #f26649;
+            --ala-secondary: #c44d34;
+            --ala-link: #003a70;
+            --ala-text: #212121;
+        }
+        .swatch { width: 80px; height: 80px; border: 1px solid #ccc; display: inline-block; }
+        .swatch-label { font: 12px/1.4 sans-serif; text-align: center; }
+    </style>
+</head>
+<body>
+<div id="header-placeholder"></div>
+
+<main class="container mt-4">
+    <h1>Theme Test Page</h1>
+    <p class="lead">Use this page to visually verify your theme assets.</p>
+
+    <section class="mb-5">
+        <h2>Colours</h2>
+        <div class="d-flex gap-2 flex-wrap">
+            <div><div class="swatch" style="background: var(--ala-primary)"></div><div class="swatch-label">--ala-primary</div></div>
+            <div><div class="swatch" style="background: var(--ala-secondary)"></div><div class="swatch-label">--ala-secondary</div></div>
+            <div><div class="swatch" style="background: var(--ala-link)"></div><div class="swatch-label">--ala-link</div></div>
+            <div><div class="swatch" style="background: var(--ala-text)"></div><div class="swatch-label">--ala-text</div></div>
+        </div>
+    </section>
+
+    <section class="mb-5">
+        <h2>Buttons</h2>
+        <button class="btn btn-primary me-2">btn-primary</button>
+        <button class="btn btn-secondary me-2">btn-secondary</button>
+        <button class="btn ala-btn-primary me-2">ala-btn-primary</button>
+        <button class="btn ala-btn-secondary me-2">ala-btn-secondary</button>
+    </section>
+
+    <section class="mb-5">
+        <h2>Typography</h2>
+        <h1>Heading 1</h1><h2>Heading 2</h2><h3>Heading 3</h3>
+        <p>Body text. <a href="#">A link</a>. <strong>Bold</strong>. <em>Italic</em>.</p>
+    </section>
+
+    <section class="mb-5">
+        <h2>Forms</h2>
+        <input class="form-control mb-2" type="text" placeholder="Text input">
+        <select class="form-select mb-2"><option>Select option</option></select>
+        <div class="form-check">
+            <input class="form-check-input" type="checkbox" id="chk">
+            <label class="form-check-label" for="chk">Checkbox</label>
+        </div>
+    </section>
+
+    <section class="mb-5">
+        <h2>Alerts</h2>
+        <div class="alert alert-info">Info alert</div>
+        <div class="alert alert-warning">Warning alert</div>
+        <div class="alert alert-danger">Danger alert</div>
+    </section>
+</main>
+
+<div id="footer-placeholder"></div>
+
+<script>
+    // Resolve the theme from a single ?theme= param (mirrors how the app reads theme.json),
+    // then inject CSS and load header/footer. Individual params override for one-off testing.
+    (async function () {
+        var params = new URLSearchParams(location.search);
+
+        // Defaults = ALA baseline.
+        var cfg = {
+            cssUrls: ['common/ala-combined.css'],
+            headerUrl: 'common/banner.mustache',
+            footerUrl: 'common/footer.mustache',
+            logoUrl: 'https://www.ala.org.au/app/uploads/2019/01/logo.png'
+        };
+
+        // ?theme=community  -> themes/community/theme.json ; also accepts a full path/URL.
+        var t = params.get('theme');
+        if (t) {
+            var manifestUrl = (/\.json|\/|:/.test(t)) ? t : 'themes/' + t + '/theme.json';
+            try {
+                var m = await (await fetch(manifestUrl)).json();
+                if (m.cssUrls && m.cssUrls.length) cfg.cssUrls = m.cssUrls;
+                if (m.headerUrl) cfg.headerUrl = m.headerUrl;
+                if (m.footerUrl) cfg.footerUrl = m.footerUrl;
+                if (m.logoUrl) cfg.logoUrl = m.logoUrl;
+            } catch (e) {
+                console.warn('[testPage] could not load theme manifest', manifestUrl, e);
+            }
+        }
+        // One-off overrides.
+        if (params.get('cssUrl')) cfg.cssUrls = params.get('cssUrl').split(',');
+        if (params.get('headerUrl')) cfg.headerUrl = params.get('headerUrl');
+        if (params.get('footerUrl')) cfg.footerUrl = params.get('footerUrl');
+        if (params.get('logoUrl')) cfg.logoUrl = params.get('logoUrl');
+
+        // Inject CSS.
+        cfg.cssUrls.map(function (u) { return (u || '').trim(); }).filter(Boolean).forEach(function (u) {
+            var link = document.createElement('link');
+            link.rel = 'stylesheet';
+            link.href = u;
+            document.head.appendChild(link);
+        });
+
+        // Load header/footer mustache (DOMParser + importNode, no innerHTML).
+        function loadTemplate(url, placeholderId) {
+            fetch(url).then(function (r) { return r.text(); }).then(function (html) {
+                var clean = html
+                    .replace(/\{\{containerClass}}/g, 'container-fluid')
+                    .replace(/\{\{logoUrl}}/g, cfg.logoUrl)
+                    .replace(/\{\{|}}/g, '');
+                var doc = new DOMParser().parseFromString(clean, 'text/html');
+                var target = document.getElementById(placeholderId);
+                Array.prototype.slice.call(doc.body.childNodes).forEach(function (node) {
+                    target.appendChild(document.importNode(node, true));
+                });
+            });
+        }
+        loadTemplate(cfg.headerUrl, 'header-placeholder');
+        loadTemplate(cfg.footerUrl, 'footer-placeholder');
+    })();
+</script>
+</body>
+</html>

--- a/static-server/static/themes/README.md
+++ b/static-server/static/themes/README.md
@@ -1,0 +1,15 @@
+# Test themes (dev only)
+
+Runtime theme bundles used to develop and review the theming work. They live here as **test
+directories** for now; once the PR is accepted, a bundle like `community/` is meant to be
+extracted into its own repo and self-hosted as static pages on any static web server — a
+portal then themes the prebuilt app at runtime, no fork or rebuild of atlas-index.
+
+| Theme | Purpose |
+|---|---|
+| [`ala/`](ala/) | Reproduces the current ALA look. Applying it should be **identical to no theme** → regression check ("does the theming break anything?"). |
+| [`community/`](community/) | A non-ALA brand (teal + Living Atlases artwork) — the copy-and-host template/example. See its `README.md`. |
+
+Serve them with the dev static-server (`npx http-server -p 8082 --cors -c-1 static-server` from
+the repo root area) and point a UI's `config.js` at e.g.
+`http://localhost:8082/static/themes/ala/theme.json`.

--- a/static-server/static/themes/ala/theme.css
+++ b/static-server/static/themes/ala/theme.css
@@ -1,0 +1,11 @@
+/* ALA baseline theme. Loads the real ALA base CSS and pins the brand variables to ALA's own
+   values. Because the apps use var(--ala-x, <ALA hex>) with ALA fallbacks, applying this theme
+   must be byte-for-byte the same as running with no theme at all — i.e. the regression check. */
+@import url("http://localhost:8082/static/common/ala-combined.css");
+
+:root {
+    --ala-primary:   #f26649;
+    --ala-secondary: #c44d34;
+    --ala-link:      #003a70;
+    --ala-text:      #212121;
+}

--- a/static-server/static/themes/ala/theme.json
+++ b/static-server/static/themes/ala/theme.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "ALA baseline theme — reproduces the current look. Applying it must be visually identical to the no-theme default (regression check). Dev URLs assume the static-server on :8082.",
+  "cssUrls": ["http://localhost:8082/static/themes/ala/theme.css"],
+  "jsUrls": ["http://localhost:8082/static/common/ala-combined.js"],
+  "headerUrl": "http://localhost:8082/static/common/banner.mustache",
+  "footerUrl": "http://localhost:8082/static/common/footer.mustache",
+  "logoUrl": "https://www.ala.org.au/app/uploads/2019/01/logo.png",
+  "homeUrl": "https://www.ala.org.au",
+  "defaultLocale": "en",
+  "locales": [{ "code": "en", "label": "English", "messagesUrl": "" }]
+}

--- a/static-server/static/themes/community/README.md
+++ b/static-server/static/themes/community/README.md
@@ -1,0 +1,44 @@
+# Community theme (example / template)
+
+A copy-and-host **theme** for the atlas-index UIs, used here as an in-repo **test theme** while
+the runtime-theming PR is under review. If the PR is accepted, this folder is the template to
+extract into its own repo (e.g. `la-theme-starter`) and **self-host as static pages** on any
+static web server — **no fork or rebuild of atlas-index needed to theme a portal.**
+
+## Files
+
+| File | What it is | Edit it? |
+|---|---|---|
+| `theme.json` | Manifest the app fetches; lists the URLs below | ✅ URLs + `homeUrl` |
+| `theme.css` | Brand: 4 `--ala-*` values (+RGB) + `--bs-*` palette + chrome overrides | ✅ the 4 colours |
+| `banner.mustache` | Header HTML (self-styled; logo via `{{logoUrl}}`, menu links) | ✅ |
+| `footer.mustache` | Footer HTML (columns, links, logo, copyright) | ✅ |
+| `i18n/en.json` | UI strings (Crowdin-compatible) | optional |
+| `preview.html` | Local preview | — |
+
+Logo here comes from the community artwork repo
+(<https://github.com/living-atlases/artwork> → `la-logo.svg`).
+
+## Try it locally (no rebuild)
+
+1. Serve this repo's static dir: from `atlas-index/static-server`, run
+   `npx http-server -p 8082 --cors -c-1 .`
+2. Point a UI at it via its runtime `config.js` (served at the app root, overwrite — no rebuild):
+   ```js
+   window.APP_CONFIG = {
+     VITE_THEME_CONFIG_URL: "http://localhost:8082/static/themes/community/theme.json"
+   };
+   ```
+3. Run the UI (e.g. `npm --prefix search-ui run dev`) → teal brand + LA logo + custom footer.
+4. Preview just the theme assets: open <http://localhost:8082/static/themes/community/preview.html>.
+
+There is also an **`ala`** theme next to this one (`../ala/theme.json`) that reproduces the
+current ALA look — applying it should be identical to running with no theme (regression check).
+
+## To host for real (when extracted to a repo)
+
+Self-host these static files on any static web server. Replace the
+`http://localhost:8082/static/themes/community` URLs in `theme.json` with
+your hosting URL, and set `VITE_THEME_CONFIG_URL` in the portal's `config.js` to your hosted
+`theme.json`. The host must send permissive CORS (`Access-Control-Allow-Origin`) since the app
+fetches these assets cross-origin.

--- a/static-server/static/themes/community/banner.mustache
+++ b/static-server/static/themes/community/banner.mustache
@@ -1,0 +1,28 @@
+<!-- Your portal header. Self-styled so it looks right on its own (no dependency on ALA's CSS).
+     Edit the logo link, nav links and labels. Keep the loginBtn/logoutBtn/loginStatus classes:
+     the app wires login/logout and shows the right one based on auth state.
+     (For the full ALA header with autocomplete search, copy atlas-index's
+      static-server/static/common/banner.mustache instead.) -->
+<header style="background:#fff;border-bottom:4px solid var(--ala-primary,#1f7a8c);box-shadow:0 1px 4px rgba(0,0,0,.08)">
+    <a class="skip-link" href="#INSERT_CONTENT_ID_HERE"
+       style="position:absolute;left:-999px">Skip to content</a>
+    <div class="{{containerClass}}"
+         style="display:flex;align-items:center;justify-content:space-between;gap:24px;padding:10px 32px">
+        <a href="/" style="display:flex;align-items:center;gap:12px;text-decoration:none">
+            <img src="{{logoUrl}}" alt="" height="40" style="width:auto;display:block">
+            <span style="font-weight:700;font-size:18px;line-height:1.1;color:var(--ala-text,#0f3d47)">Living&nbsp;Atlas</span>
+        </a>
+        <nav style="display:flex;gap:24px;align-items:center;flex-wrap:wrap">
+            <a href="/" style="color:var(--ala-text,#0f3d47);text-decoration:none;font-weight:600">Search</a>
+            <a href="/" style="color:var(--ala-text,#0f3d47);text-decoration:none;font-weight:600">Explore</a>
+            <a href="/" style="color:var(--ala-text,#0f3d47);text-decoration:none;font-weight:600">Contribute</a>
+            <a href="/" style="color:var(--ala-text,#0f3d47);text-decoration:none;font-weight:600">About</a>
+            <span class="loginStatus">
+                <button class="loginBtn signedOut"
+                        style="background:var(--ala-primary,#1f7a8c);color:#fff;border:0;border-radius:6px;padding:8px 16px;font-weight:600;cursor:pointer">Log in</button>
+                <button class="logoutBtn signedIn"
+                        style="background:transparent;color:var(--ala-primary,#1f7a8c);border:1px solid var(--ala-primary,#1f7a8c);border-radius:6px;padding:8px 16px;font-weight:600;cursor:pointer">Log out</button>
+            </span>
+        </nav>
+    </div>
+</header>

--- a/static-server/static/themes/community/footer.mustache
+++ b/static-server/static/themes/community/footer.mustache
@@ -1,0 +1,39 @@
+<!-- Your portal footer. Pure HTML — edit freely: columns, links, logo, social, copyright.
+     {{containerClass}} is substituted by the app; other {{...}} are stripped. -->
+<footer class="{{containerClass}}" style="background:#0a3d1f;color:#fff;padding:40px 24px">
+    <div style="display:flex;gap:48px;flex-wrap:wrap;max-width:1100px;margin:0 auto">
+        <div style="flex:1;min-width:200px">
+            <img src="{{logoUrl}}" alt="Your portal" height="40" style="filter:brightness(0) invert(1)">
+            <p style="margin-top:12px;font-size:14px;opacity:.85">
+                One-line description of your Living Atlas portal.
+            </p>
+        </div>
+        <div style="min-width:160px">
+            <h4 style="font-size:15px;text-transform:uppercase;letter-spacing:.05em">Explore</h4>
+            <ul style="list-style:none;padding:0;line-height:2;font-size:14px">
+                <li><a href="/" style="color:#9fe6b0;text-decoration:none">Species</a></li>
+                <li><a href="/" style="color:#9fe6b0;text-decoration:none">Datasets</a></li>
+                <li><a href="/" style="color:#9fe6b0;text-decoration:none">Regions</a></li>
+                <li><a href="/" style="color:#9fe6b0;text-decoration:none">Occurrences</a></li>
+            </ul>
+        </div>
+        <div style="min-width:160px">
+            <h4 style="font-size:15px;text-transform:uppercase;letter-spacing:.05em">About</h4>
+            <ul style="list-style:none;padding:0;line-height:2;font-size:14px">
+                <li><a href="/" style="color:#9fe6b0;text-decoration:none">Our node</a></li>
+                <li><a href="/" style="color:#9fe6b0;text-decoration:none">Contact</a></li>
+                <li><a href="/" style="color:#9fe6b0;text-decoration:none">API</a></li>
+            </ul>
+        </div>
+        <div style="min-width:160px">
+            <h4 style="font-size:15px;text-transform:uppercase;letter-spacing:.05em">Follow</h4>
+            <ul style="list-style:none;padding:0;line-height:2;font-size:14px">
+                <li><a href="/" style="color:#9fe6b0;text-decoration:none">Mastodon</a></li>
+                <li><a href="/" style="color:#9fe6b0;text-decoration:none">GitHub</a></li>
+            </ul>
+        </div>
+    </div>
+    <div style="border-top:1px solid #1f6b3a;margin-top:28px;padding-top:16px;text-align:center;font-size:13px;opacity:.8;max-width:1100px;margin-left:auto;margin-right:auto">
+        © 2026 Your Organisation · Powered by atlas-index
+    </div>
+</footer>

--- a/static-server/static/themes/community/i18n/en.json
+++ b/static-server/static/themes/community/i18n/en.json
@@ -1,0 +1,5 @@
+{
+  "_comment": "Crowdin-compatible flat i18n. Translate values; add i18n/<locale>.json files and list them in theme.json -> locales.",
+  "search.placeholder": "Search the Atlas...",
+  "footer.copyright": "© 2026 Your Organisation"
+}

--- a/static-server/static/themes/community/preview.html
+++ b/static-server/static/themes/community/preview.html
@@ -1,0 +1,61 @@
+<!DOCTYPE html>
+<!-- Local preview for theme authors. Serve this folder (e.g. `npx http-server -p 9000 .`)
+     and open http://localhost:9000/preview.html to eyeball your theme.css + header/footer
+     before hosting. Loads the files in this folder by relative path. -->
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Theme preview</title>
+    <link rel="stylesheet" href="./theme.css">
+    <style>
+        .swatch { width: 80px; height: 80px; border: 1px solid #ccc; display: inline-block; }
+        .swatch-label { font: 12px/1.4 sans-serif; text-align: center; }
+        body { margin: 0; }
+        main { padding: 24px; }
+    </style>
+</head>
+<body>
+<div id="header-placeholder"></div>
+
+<main class="container">
+    <h1>Theme preview</h1>
+    <p class="lead">Edit <code>theme.css</code> and reload to see your brand applied.</p>
+
+    <h2>Brand colours</h2>
+    <div style="display:flex;gap:8px;flex-wrap:wrap">
+        <div><div class="swatch" style="background:var(--ala-primary)"></div><div class="swatch-label">--ala-primary</div></div>
+        <div><div class="swatch" style="background:var(--ala-secondary)"></div><div class="swatch-label">--ala-secondary</div></div>
+        <div><div class="swatch" style="background:var(--ala-link)"></div><div class="swatch-label">--ala-link</div></div>
+        <div><div class="swatch" style="background:var(--ala-text)"></div><div class="swatch-label">--ala-text</div></div>
+    </div>
+
+    <h2 style="margin-top:32px">Buttons &amp; links</h2>
+    <button class="btn btn-primary me-2">btn-primary</button>
+    <button class="btn btn-secondary me-2">btn-secondary</button>
+    <a href="#">A link</a>
+</main>
+
+<div id="footer-placeholder"></div>
+
+<script>
+    // Mirror cleanMustache: substitute {{containerClass}}/{{logoUrl}}, strip the rest.
+    var logoUrl = 'https://raw.githubusercontent.com/living-atlases/artwork/master/la-logo.svg';
+    function load(url, id) {
+        fetch(url).then(function (r) { return r.text(); }).then(function (html) {
+            var clean = html
+                .replace(/\{\{containerClass}}/g, 'container-fluid')
+                .replace(/\{\{logoUrl}}/g, logoUrl)
+                .replace(/\{\{|}}/g, '');
+            var doc = new DOMParser().parseFromString(clean, 'text/html');
+            var target = document.getElementById(id);
+            Array.prototype.slice.call(doc.body.childNodes).forEach(function (n) {
+                target.appendChild(document.importNode(n, true));
+            });
+        });
+    }
+    load('./banner.mustache', 'header-placeholder');
+    load('./footer.mustache', 'footer-placeholder');
+</script>
+</body>
+</html>

--- a/static-server/static/themes/community/theme.css
+++ b/static-server/static/themes/community/theme.css
@@ -1,0 +1,41 @@
+/* Living Atlases community example theme — teal brand, to show a non-ALA brand applies cleanly.
+   Rebrand by editing the 4 --ala-* values (+ their RGB). See README.md. */
+@import url("http://localhost:8082/static/common/ala-combined.css");
+
+:root {
+    --ala-primary:   #1f7a8c;  /* main brand */
+    --ala-secondary: #15596b;  /* darker shade */
+    --ala-link:      #1f7a8c;  /* links */
+    --ala-text:      #0f3d47;  /* strong text/borders */
+
+    --ala-primary-rgb:   31, 122, 140;
+    --ala-secondary-rgb: 21, 89, 107;
+
+    /* Bootstrap brand palette — recolours shared chrome (links/titles/focus) across all UIs. */
+    --bs-primary: var(--ala-primary);
+    --bs-secondary: var(--ala-secondary);
+    --bs-primary-rgb: var(--ala-primary-rgb);
+    --bs-secondary-rgb: var(--ala-secondary-rgb);
+    --bs-link-color: var(--ala-link);
+    --bs-link-color-rgb: var(--ala-primary-rgb);
+    --bs-link-hover-color: var(--ala-secondary);
+    --bs-focus-ring-color: rgba(var(--ala-primary-rgb), 0.25);
+}
+
+/* SASS-compiled literals in ala-combined.css (buttons, skip-link) need explicit overrides. */
+.btn-primary,
+.btn-primary:focus,
+.btn.btn-primary {
+    background-color: var(--ala-primary) !important;
+    border-color: var(--ala-primary) !important;
+}
+.btn-primary:hover,
+.btn-primary:active,
+.btn.btn-primary:hover {
+    background-color: var(--ala-secondary) !important;
+    border-color: var(--ala-secondary) !important;
+}
+.skip-link {
+    color: var(--ala-secondary) !important;
+    border-color: var(--ala-secondary) !important;
+}

--- a/static-server/static/themes/community/theme.json
+++ b/static-server/static/themes/community/theme.json
@@ -1,0 +1,11 @@
+{
+  "_comment": "Living Atlases community example theme. Dev URLs assume the static-server on :8082. To host for real, self-host these static files on any static web server and replace the http://localhost:8082/static/themes/community URLs with your hosting URL (see README.md).",
+  "cssUrls": ["http://localhost:8082/static/themes/community/theme.css"],
+  "jsUrls": [],
+  "headerUrl": "http://localhost:8082/static/themes/community/banner.mustache",
+  "footerUrl": "http://localhost:8082/static/themes/community/footer.mustache",
+  "logoUrl": "https://raw.githubusercontent.com/living-atlases/artwork/master/la-logo.svg",
+  "homeUrl": "https://living-atlases.gbif.org",
+  "defaultLocale": "en",
+  "locales": [{ "code": "en", "label": "English", "messagesUrl": "http://localhost:8082/static/themes/community/i18n/en.json" }]
+}


### PR DESCRIPTION
Following [this proposal](https://atlaslivingaustralia.slack.com/archives/CCTFGEU1G/p1758106052346249?thread_ts=1757939047.536369&cid=CCTFGEU1G) this PR makes the brand of a prebuilt atlas-index SPA configurable at runtime (no rebuild, no fork). A portal hosts a theme bundle (CSS, header/footer/banner Mustache, logo, i18n) on any static server and points a one-line `/config.js` at it. Implemented end-to-end on **`search-ui`** as the reference UI.

This is a proof-of-concept of the runtime brand pointer + colour/logo theming. It is **safe by construction**: everything falls back to the existing build-time env vars, so with no theme configured the app is pixel-identical to current `develop`.

### Included
- **Runtime config pointer** — `common-ui/util/runtimeConfig.ts` (`getRuntimeConfig`), `search-ui/public/config.js` (un-hashed `window.APP_CONFIG`), `<script src="/config.js">` in `index.html`. `App.tsx` resolves `VITE_THEME_CONFIG_URL` at runtime with fallback to `import.meta.env`.
- **Theme core** — `common-ui/util/theme.ts` (`ThemeConfig`, `fetchThemeConfig`), `common-ui/hooks/useTheme.ts` (fetches `theme.json` manifest, injects CSS via existing `injectCommonInfo`), `search-ui/config/alaDefaultTheme.ts` fallback, `VITE_THEME_CONFIG_URL` typed in `vite-env.d.ts`.
- **`{{logoUrl}}`** — optional `logoUrl` on `cleanMustache`, `Header` and `Footer` (defaults to the ALA logo so the shared `banner.mustache` keeps working for every UI).
- **Full colour var-ization of search-ui** — every ALA hex → `var(--ala-x, #hex)` across all `*.css`/`*.module.css` and inline JSX. Order-independent (no app `:root` block). Verified: search-ui landing renders 0 ALA-orange under a theme.
- **Theme QA** — `static-server/static/testPage.html` and two in-repo dev test themes (`ala/` = regression check, `community/` = non-ALA brand demo).
- **Runtime favicon + page title** via `window.APP_CONFIG`.

### Maps to original blueprint goals

Resolves **G1** (runtime theme, no rebuild), **G2** (external theme hosting mechanism), **G7** (docs + testPage), **G8** (no breaking changes) — for `search-ui`.

### Screenshots

ALA theme:

<img width="1440" height="900" alt="ala-baseline-home" src="https://github.com/user-attachments/assets/d06be0d7-400f-45e9-b0b9-a56eba1dae4a" />

Community sample theme:

<img width="1440" height="900" alt="community-theme-home" src="https://github.com/user-attachments/assets/ba895269-fc02-41ac-bd54-cafbd13ba54b" />
